### PR TITLE
Error raised in Update Tests

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -155,10 +155,10 @@ def update_a_supplier(supplier_id):
     check_content_type('application/json')
     data = request.get_json()
     supplier = Supplier.find(supplier_id)
-    supplier.update(**data)
-    supplier.reload()
     if not supplier:
         raise NotFound("Supplier with id '{}' was not found.".format(supplier_id))
+    supplier.update(**data)
+    supplier.reload()
     return make_response(supplier.to_json(), status.HTTP_201_CREATED)
 
 ######################################################################

--- a/service/service.py
+++ b/service/service.py
@@ -159,7 +159,7 @@ def update_a_supplier(supplier_id):
         raise NotFound("Supplier with id '{}' was not found.".format(supplier_id))
     supplier.update(**data)
     supplier.reload()
-    return make_response(supplier.to_json(), status.HTTP_201_CREATED)
+    return make_response(supplier.to_json(), status.HTTP_200_OK)
 
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -60,8 +60,7 @@ class TestSupplierServer(unittest.TestCase):
             self.assertEqual(resp.status_code, status.HTTP_201_CREATED, 'Could not create test supplier')
 
             new_supplier = json.loads(resp.data)
-            test_supplier.id = new_supplier["_id"]["$oid"]
-            
+            test_supplier.id = new_supplier["_id"]["$oid"]            
             suppliers.append(test_supplier)
         return suppliers
 
@@ -111,11 +110,11 @@ class TestSupplierServer(unittest.TestCase):
         # update the supplier
         new_supplier = json.loads(resp.data)
         new_supplier['address'] = 'unknown'
-        resp = self.app.put('/suppliers/{}'.format(new_supplier['id']),
+        resp = self.app.put('/suppliers/{}'.format(new_supplier["_id"]["$oid"]),
                             json=new_supplier,
                             content_type='application/json')
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        updated_supplier = resp.get_json()
+        updated_supplier = json.loads(resp.data)
         self.assertEqual(updated_supplier['address'], 'unknown')
 
 

--- a/tests/test_suppliers.py
+++ b/tests/test_suppliers.py
@@ -37,13 +37,13 @@ class TestSuppliers(unittest.TestCase):
     def setUp(self):      
         disconnect('default')
         global db
-        db = connect('mydatabase')
+        db = connect('testdb')
         # self.app = app.test_client()
-        db.drop_database('mydatabase')
+        db.drop_database('testdb')
 
     def tearDown(self):
-        db.drop_database('mydatabase')
-        disconnect('mydatabase')
+        db.drop_database('testdb')
+        disconnect('testdb')
 
     def test_serialize_a_supplier(self):
         """ Test serialization of a Supplier """


### PR DESCRIPTION
Run nosetests and get:
```
======================================================================
FAIL: Update an existing supplier
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vagrant/tests/test_service.py", line 116, in test_update_supplier
    self.assertEqual(resp.status_code, status.HTTP_200_OK)
AssertionError: 500 != 200
-------------------- >> begin captured logging << --------------------
service: INFO: Request to create a supplier
service: INFO: Request to update a supplier
flask.app: INFO: Getting supplier with id: %s
service: ERROR: Exception on /suppliers/5da6476932aad4a691716dd4 [PUT]
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/mongoengine/queryset/transform.py", line 236, in update
    fields = _doc_cls._lookup_field(parts)
  File "/usr/local/lib/python3.6/dist-packages/mongoengine/base/document.py", line 1032, in _lookup_field
    raise LookUpError('Cannot resolve field "%s"' % field_name)
mongoengine.errors.LookUpError: Cannot resolve field "_id"

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/dist-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.6/dist-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/vagrant/service/service.py", line 160, in update_a_supplier
    supplier.update(**data)
  File "/usr/local/lib/python3.6/dist-packages/mongoengine/document.py", line 590, in update
    return self._qs.filter(**self._object_key).update_one(**kwargs)
  File "/usr/local/lib/python3.6/dist-packages/mongoengine/queryset/base.py", line 593, in update_one
    **update)
  File "/usr/local/lib/python3.6/dist-packages/mongoengine/queryset/base.py", line 517, in update
    update = transform.update(queryset._document, **update)
  File "/usr/local/lib/python3.6/dist-packages/mongoengine/queryset/transform.py", line 238, in update
    raise InvalidQueryError(e)
mongoengine.errors.InvalidQueryError: Cannot resolve field "_id"
service: ERROR: 500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
```