### PR TITLE
Handle empty Content-Type and typo fix

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -163,6 +163,12 @@ def init_db():
 
 def check_content_type(content_type):
     """ Checks whether the request content type is correct """
+    try:
+        request.headers['Content-Type']
+    except KeyError as error:
+        app.logger.error(
+            'Null Content-Type')
+        abort(415, 'Content-Type is missing')
     if request.headers['Content-Type'] != content_type:
         app.logger.error('Invalid Content-Type: %s', request.headers['Content-Type'])
         abort(415, 'Content-Type must be {}'.format(content_type))


### PR DESCRIPTION
Fixed an error when the incoming data response does not have a Content-Type field in the Header 

![image](https://user-images.githubusercontent.com/17645845/66946150-53600e80-f01e-11e9-9277-b8f0c50461d9.png)
reported by @silemie 